### PR TITLE
CC-38: Refactor API Version Prefix to Constant

### DIFF
--- a/backend/cmd/app/routes.go
+++ b/backend/cmd/app/routes.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/jshelley8117/CodeCart/internal/client"
+	"github.com/jshelley8117/CodeCart/internal/common"
 	"github.com/jshelley8117/CodeCart/internal/handler"
 	"github.com/jshelley8117/CodeCart/internal/middleware"
 	"github.com/jshelley8117/CodeCart/internal/persistence"
@@ -20,28 +21,28 @@ func SetupRoutes(mux *http.ServeMux, resourceConfig ResourceConfig) {
 	userService := service.NewUserService(userPersistence, resourceConfig.FirebaseAuth)
 	userHandler := handler.NewUserHandler(userService)
 
-	mux.HandleFunc("POST /api/v1/users", userHandler.HandleCreateUser)
+	mux.HandleFunc("POST " + common.APIBasePath + "/users", userHandler.HandleCreateUser)
 
 	// ---------- CUSTOMERS DOMAIN ----------
 	customerPersistence := persistence.NewCustomerPersistence(resourceConfig.GCloudDB)
 	customerService := service.NewCustomerService(customerPersistence)
 	customerHandler := handler.NewCustomerHandler(customerService)
 
-	mux.Handle("POST /api/v1/customers", authMW(adminMW(http.HandlerFunc(customerHandler.HandleCreateCustomer))))
-	mux.Handle("GET /api/v1/customers", authMW(adminMW(http.HandlerFunc(customerHandler.HandleGetAllCustomers))))
-	mux.Handle("DELETE /api/v1/customers/{id}", authMW(adminMW(http.HandlerFunc(customerHandler.HandleDeleteCustomerById))))
-	mux.Handle("PATCH /api/v1/customers/{id}", authMW(adminMW(http.HandlerFunc(customerHandler.HandleUpdateCustomerById))))
+	mux.Handle("POST " + common.APIBasePath + "/customers", authMW(adminMW(http.HandlerFunc(customerHandler.HandleCreateCustomer))))
+	mux.Handle("GET " + common.APIBasePath + "/customers", authMW(adminMW(http.HandlerFunc(customerHandler.HandleGetAllCustomers))))
+	mux.Handle("DELETE " + common.APIBasePath + "/customers/{id}", authMW(adminMW(http.HandlerFunc(customerHandler.HandleDeleteCustomerById))))
+	mux.Handle("PATCH " + common.APIBasePath + "/customers/{id}", authMW(adminMW(http.HandlerFunc(customerHandler.HandleUpdateCustomerById))))
 
 	// ---------- ADDRESS DOMAIN ----------
 	addressPersistence := persistence.NewAddressPersistence(resourceConfig.GCloudDB)
 	addressService := service.NewAddressService(addressPersistence)
 	addressHandler := handler.NewAddressHandler(addressService)
 
-	mux.Handle("POST /api/v1/addresses", authMW(http.HandlerFunc(addressHandler.HandleCreateAddress)))
-	mux.Handle("GET /api/v1/addresses", authMW(http.HandlerFunc(addressHandler.HandleGetAllAddressesById)))
-	mux.Handle("GET /api/v1/addresses/{id}", authMW(http.HandlerFunc(addressHandler.HandleGetAddressById)))
-	mux.Handle("PATCH /api/v1/addresses/{id}", authMW(http.HandlerFunc(addressHandler.HandleUpdateAddressById)))
-	mux.Handle("DELETE /api/v1/addresses/{id}", authMW(http.HandlerFunc(addressHandler.HandleDeleteAddressById)))
+	mux.Handle("POST " + common.APIBasePath + "/addresses", authMW(http.HandlerFunc(addressHandler.HandleCreateAddress)))
+	mux.Handle("GET " + common.APIBasePath + "/addresses", authMW(http.HandlerFunc(addressHandler.HandleGetAllAddressesById)))
+	mux.Handle("GET " + common.APIBasePath + "/addresses/{id}", authMW(http.HandlerFunc(addressHandler.HandleGetAddressById)))
+	mux.Handle("PATCH " + common.APIBasePath + "/addresses/{id}", authMW(http.HandlerFunc(addressHandler.HandleUpdateAddressById)))
+	mux.Handle("DELETE " + common.APIBasePath + "/addresses/{id}", authMW(http.HandlerFunc(addressHandler.HandleDeleteAddressById)))
 
 	// ---------- CLOUD FUNCTION POC DOMAIN ----------
 	cloudFunctionClient := client.NewCloudFunctionClient(os.Getenv("GCP_IMP_SA"))
@@ -54,52 +55,52 @@ func SetupRoutes(mux *http.ServeMux, resourceConfig ResourceConfig) {
 	)
 	cloudFunctionHandler := handler.NewCloudFunctionHandler(cloudFunctionService)
 
-	mux.HandleFunc("GET /api/v1/hw", cloudFunctionHandler.HandleGetHelloWorld)
-	mux.HandleFunc("GET /api/v1/hw2", cloudFunctionHandler.HandleGetHelloWorld2)
+	mux.HandleFunc("GET " + common.APIBasePath + "/hw", cloudFunctionHandler.HandleGetHelloWorld)
+	mux.HandleFunc("GET " + common.APIBasePath + "/hw2", cloudFunctionHandler.HandleGetHelloWorld2)
 
 	// ---------- ORDERS DOMAIN ----------
 	orderPersistence := persistence.NewOrderPersistence(resourceConfig.GCloudDB)
 	orderService := service.NewOrderService(orderPersistence)
 	orderHandler := handler.NewOrderHandler(orderService)
 
-	mux.Handle("POST /api/v1/orders", authMW(http.HandlerFunc(orderHandler.HandleCreateOrder)))
-	mux.Handle("GET /api/v1/orders", authMW(http.HandlerFunc(orderHandler.HandleGetAllOrders)))
-	mux.Handle("GET /api/v1/orders/{id}", authMW(http.HandlerFunc(orderHandler.HandleGetAllOrders)))
-	mux.Handle("PATCH /api/v1/orders/{id}", authMW(http.HandlerFunc(orderHandler.HandleUpdateOrderById)))
+	mux.Handle("POST " + common.APIBasePath + "/orders", authMW(http.HandlerFunc(orderHandler.HandleCreateOrder)))
+	mux.Handle("GET " + common.APIBasePath + "/orders", authMW(http.HandlerFunc(orderHandler.HandleGetAllOrders)))
+	mux.Handle("GET " + common.APIBasePath + "/orders/{id}", authMW(http.HandlerFunc(orderHandler.HandleGetAllOrders)))
+	mux.Handle("PATCH " + common.APIBasePath + "/orders/{id}", authMW(http.HandlerFunc(orderHandler.HandleUpdateOrderById)))
 
 	// ---------- PRODUCTS DOMAIN ----------
 	productPersistence := persistence.NewProductPersistence(resourceConfig.GCloudDB)
 	productService := service.NewProductService(productPersistence)
 	productHandler := handler.NewProductHandler(productService)
 
-	mux.Handle("POST /api/v1/products", authMW(adminMW(http.HandlerFunc(productHandler.HandleCreateProduct))))
-	mux.HandleFunc("GET /api/v1/products", productHandler.HandleGetAllProducts)
-	mux.HandleFunc("GET /api/v1/products/{id}", productHandler.HandleGetProductById)
-	mux.HandleFunc("GET /api/v1/products/{id}/variants", productHandler.HandleGetAllProductVariantsByProductId)
-	mux.Handle("PATCH /api/v1/products/{id}", authMW(adminMW(http.HandlerFunc(productHandler.HandleUpdateProductById))))
-	mux.Handle("PATCH /api/v1/products/variants/{id}", authMW(adminMW(http.HandlerFunc(productHandler.HandleUpdateProductVariantById))))
-	mux.Handle("DELETE /api/v1/products/{id}", authMW(adminMW(http.HandlerFunc(productHandler.HandleDeleteProductById))))
-	mux.Handle("DELETE /api/v1/products/variants/{id}", authMW(adminMW(http.HandlerFunc(productHandler.HandleDeleteProductVariantById))))
+	mux.Handle("POST " + common.APIBasePath + "/products", authMW(adminMW(http.HandlerFunc(productHandler.HandleCreateProduct))))
+	mux.HandleFunc("GET " + common.APIBasePath + "/products", productHandler.HandleGetAllProducts)
+	mux.HandleFunc("GET " + common.APIBasePath + "/products/{id}", productHandler.HandleGetProductById)
+	mux.HandleFunc("GET " + common.APIBasePath + "/products/{id}/variants", productHandler.HandleGetAllProductVariantsByProductId)
+	mux.Handle("PATCH " + common.APIBasePath + "/products/{id}", authMW(adminMW(http.HandlerFunc(productHandler.HandleUpdateProductById))))
+	mux.Handle("PATCH " + common.APIBasePath + "/products/variants/{id}", authMW(adminMW(http.HandlerFunc(productHandler.HandleUpdateProductVariantById))))
+	mux.Handle("DELETE " + common.APIBasePath + "/products/{id}", authMW(adminMW(http.HandlerFunc(productHandler.HandleDeleteProductById))))
+	mux.Handle("DELETE " + common.APIBasePath + "/products/variants/{id}", authMW(adminMW(http.HandlerFunc(productHandler.HandleDeleteProductVariantById))))
 
 	// ---------- INVENTORY DOMAIN ----------
 	inventoryPersistence := persistence.NewInventoryPersistence((resourceConfig.GCloudDB))
 	inventoryService := service.NewInventoryService(inventoryPersistence)
 	inventoryHandler := handler.NewInventoryHandler(inventoryService)
 
-	mux.Handle("POST /api/v1/inventory", authMW(adminMW(http.HandlerFunc(inventoryHandler.HandleCreateInventory))))
-	mux.Handle("GET /api/v1/inventory", authMW(adminMW(http.HandlerFunc(inventoryHandler.HandleGetAllInventory))))
-	mux.Handle("GET /api/v1/inventory/{id}", authMW(adminMW(http.HandlerFunc(inventoryHandler.HandleGetInventoryById))))
-	mux.Handle("PATCH /api/v1/inventory/{id}", authMW(adminMW(http.HandlerFunc(inventoryHandler.HandleUpdateInventoryById))))
-	mux.Handle("DELETE /api/v1/inventory/{id}", authMW(adminMW(http.HandlerFunc(inventoryHandler.HandleDeleteInventoryById))))
+	mux.Handle("POST " + common.APIBasePath + "/inventory", authMW(adminMW(http.HandlerFunc(inventoryHandler.HandleCreateInventory))))
+	mux.Handle("GET " + common.APIBasePath + "/inventory", authMW(adminMW(http.HandlerFunc(inventoryHandler.HandleGetAllInventory))))
+	mux.Handle("GET " + common.APIBasePath + "/inventory/{id}", authMW(adminMW(http.HandlerFunc(inventoryHandler.HandleGetInventoryById))))
+	mux.Handle("PATCH " + common.APIBasePath + "/inventory/{id}", authMW(adminMW(http.HandlerFunc(inventoryHandler.HandleUpdateInventoryById))))
+	mux.Handle("DELETE " + common.APIBasePath + "/inventory/{id}", authMW(adminMW(http.HandlerFunc(inventoryHandler.HandleDeleteInventoryById))))
 
 	// ---------- OrderItem DOMAIN ----------
 	orderItemPersistence := persistence.NewOrderItemPersistance(resourceConfig.GCloudDB)
 	orderItemService := service.NewOrderItemService(orderItemPersistence)
 	orderItemHandler := handler.NewOrderItemHandler(orderItemService)
 
-	mux.HandleFunc("POST /api/v1/orders/{orderId}/item", orderItemHandler.HandleCreateOrderItem)
-	mux.HandleFunc("GET /api/v1/orders/{orderId}/items", orderItemHandler.HandleGetAllOrderItems)
-	mux.HandleFunc("PATCH /api/v1/orders/{orderId}/item/{id}", orderItemHandler.HandleUpdateOrderItemById)
-	mux.HandleFunc("DELETE /api/v1/orders/{orderId}/item/{id}", orderItemHandler.HandleDeleteOrderItemById)
+	mux.HandleFunc("POST " + common.APIBasePath + "/orders/{orderId}/item", orderItemHandler.HandleCreateOrderItem)
+	mux.HandleFunc("GET " + common.APIBasePath + "/orders/{orderId}/items", orderItemHandler.HandleGetAllOrderItems)
+	mux.HandleFunc("PATCH " + common.APIBasePath + "/orders/{orderId}/item/{id}", orderItemHandler.HandleUpdateOrderItemById)
+	mux.HandleFunc("DELETE " + common.APIBasePath + "/orders/{orderId}/item/{id}", orderItemHandler.HandleDeleteOrderItemById)
 
 }

--- a/backend/internal/common/constant.go
+++ b/backend/internal/common/constant.go
@@ -15,3 +15,5 @@ type ContextKey string
 
 const ContextKeyFirebaseUID ContextKey = "firebase_uid"
 const ContextKeyRole ContextKey = "role"
+
+const APIBasePath = "/api/v1"


### PR DESCRIPTION
This change introduces:

Defined APIBasePath constant in `/backend/internal/common`
Updated all route definitions to use the constant instead of hardcoded paths

This closes #38